### PR TITLE
add bounding box to scan result

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,6 +314,10 @@ extern {
 pub struct ZBarImageScanResult {
     pub symbol_type: ZBarSymbolType,
     pub data: Vec<u8>,
+    pub left: i32,
+    pub top: i32,
+    pub bottom: i32,
+    pub right: i32,
 }
 
 pub struct ZBarImageScanner {
@@ -419,9 +423,34 @@ impl ZBarImageScanner {
                 Vec::from_raw_parts(data as *mut u8, data_length, data_length)
             };
 
+            // extract bounding box
+            let points = unsafe { zbar_symbol_get_loc_size(symbol) as usize };
+            let mut left = 0;
+            let mut right = 0;
+            let mut top = 0;
+            let mut bottom = 0;
+            for i in 0..points {
+                let x = unsafe { zbar_symbol_get_loc_x(symbol, i as u32) };
+                let y = unsafe { zbar_symbol_get_loc_y(symbol, i as u32) };
+                if i == 0 {
+                    left = x;
+                    right = x;
+                    top = x;
+                    bottom = x;
+                }
+                left = left.min(x);
+                right = right.max(x);
+                top = top.min(y);
+                bottom = bottom.max(y);
+            }
+
             let result = ZBarImageScanResult {
                 symbol_type,
                 data,
+                left,
+                right,
+                top,
+                bottom,
             };
 
             result_array.push(result);

--- a/tests/image_scanner.rs
+++ b/tests/image_scanner.rs
@@ -28,5 +28,9 @@ fn decode_qrcode() {
 
     assert_eq!(1, result.len());
     assert_eq!(ZBarSymbolType::ZBarQRCode, result[0].symbol_type);
+    assert_eq!(result[0].left, 34);
+    assert_eq!(result[0].top, 34);
+    assert_eq!(result[0].right, 479);
+    assert_eq!(result[0].bottom, 479);
     assert_eq!(url, unsafe { String::from_utf8_unchecked(result.remove(0).data) });
 }


### PR DESCRIPTION
Extract and add the bounding box to `ZBarImageScanResult`.